### PR TITLE
modify: fix possible vote deadlock

### DIFF
--- a/MapChooserSharp/Modules/MapVote/McsMapVoteController.cs
+++ b/MapChooserSharp/Modules/MapVote/McsMapVoteController.cs
@@ -395,12 +395,16 @@ internal sealed class McsMapVoteController(IServiceProvider serviceProvider) : P
         if (CurrentVoteState != McsMapVoteState.Initializing)
         {
             DebugLogger.LogWarning($"CurrentVoteState: {CurrentVoteState} is not initializing, so vote is cancelled");
+            FireVoteCancelEvent();
+            EndVotePostInitialization();
             return;
         }
 
         if (_mapVoteContent == null)
         {
             DebugLogger.LogError($"MapVoteContent is null, vote cannot be started!");
+            FireVoteCancelEvent();
+            EndVotePostInitialization();
             return;
         }
         
@@ -619,12 +623,16 @@ internal sealed class McsMapVoteController(IServiceProvider serviceProvider) : P
         if (CurrentVoteState != McsMapVoteState.Initializing)
         {
             DebugLogger.LogWarning($"CurrentVoteState: {CurrentVoteState} is not initializing, so runoff vote is cancelled");
+            FireVoteCancelEvent();
+            EndVotePostInitialization();
             return;
         }
 
         if (_mapVoteContent == null)
         {
             DebugLogger.LogError("MapVoteContent is null, runoff vote cannot be started!");
+            FireVoteCancelEvent();
+            EndVotePostInitialization();
             return;
         }
         


### PR DESCRIPTION
If !setnextmap is executed while in vote countdown, it will make a huge deadlock, so I've fix this issue by firing McsVoteCancelledEvent to notify vote cancelled state to other controllers.